### PR TITLE
Modulize and use specified version of github.com/ugorji/go/codec

### DIFF
--- a/etcd/response.generated.go
+++ b/etcd/response.generated.go
@@ -8,11 +8,12 @@ package etcd
 import (
 	"errors"
 	"fmt"
-	codec1978 "github.com/ugorji/go/codec"
 	pkg1_http "net/http"
 	"reflect"
 	"runtime"
 	time "time"
+
+	codec1978 "github.com/ugorji/go/fadd/codec"
 )
 
 const (

--- a/etcd/response.go
+++ b/etcd/response.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ugorji/go/codec"
+	"github.com/ugorji/go/fadd/codec"
 )
 
 const (

--- a/etcd/response_test.go
+++ b/etcd/response_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ugorji/go/codec"
+	"github.com/ugorji/go/fadd/codec"
 )
 
 func createTestNode(size int) *Node {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/17media/go-etcd
+
+go 1.13
+
+require github.com/ugorji/go/fadd v0.0.0-00010101000000-000000000000
+
+replace github.com/ugorji/go/fadd => github.com/ugorji/go v0.0.0-20160928015244-faddd6128c66

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/ugorji/go v0.0.0-20160928015244-faddd6128c66 h1:kkFEgasLLMuoYAgugaFI0lXRT90ONpWsLdAW0z0ujEs=
+github.com/ugorji/go v0.0.0-20160928015244-faddd6128c66/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=


### PR DESCRIPTION
## Description
- Convert this repo go modules
- Use specified version of `github.com/ugorji/go`

## Motivation and Context
- It would be easier for us to migrate to go modules
- This repo can only use the commit `faddd6128c66` of `github.com/ugorji/go`. But the other dependencies in `17media/api` also need `github.com/ugorji/go` and this would cause the final version of `github.com/ugorji/go` be some other commit due to go modules [minimal version selection](https://github.com/golang/go/wiki/Modules#version-selection). So I use a tricky way to workaround this problem. I make this repo import a non-exist package call `github.com/ugorji/go/fadd/codec` and tell go modules to replace it with a specified version of `github.com/ugorji/go` (see the `replace` section in `go.mod`).

## Remark
`github.com/coreos/go-etcd` has been deprecated 5 years ago and we should use [official package](https://github.com/etcd-io/etcd) instead. More precisely, we should deprecate `github.com/coreos/go-etcd` since [we're already using](https://github.com/17media/api/blob/master/vendor/vendor.json#L571) `github.com/etcd-io/etcd` right now.